### PR TITLE
Forward tablet navigate/revert actions for VACA devices

### DIFF
--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -6,8 +6,15 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import discovery_flow
+from homeassistant.helpers import entity_registry as er
 
-from .const import DOMAIN
+from .const import (
+    CONF_DISPLAY_DEVICE,
+    CONF_MEDIAPLAYER_DEVICE,
+    CONF_MIC_DEVICE,
+    CONF_MUSICPLAYER_DEVICE,
+    DOMAIN,
+)
 from .core import CoreManager
 from .data import set_runtime_data_for_config
 from .devices import DeviceManager
@@ -16,6 +23,56 @@ from .migration import async_migrate_view_assist_config_entry
 from .typed import VAConfigEntry, VAType
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _repair_stale_vaca_entity_ids(
+    hass: HomeAssistant, entry: VAConfigEntry
+) -> VAConfigEntry:
+    """Repair stale VACA entity ids after a tablet reinstall changes its UUID."""
+    display_device = entry.data.get(CONF_DISPLAY_DEVICE) or ""
+    if not display_device.startswith("va-"):
+        return entry
+
+    suffix = display_device.removeprefix("va-")
+    entity_registry = er.async_get(hass)
+    data = dict(entry.data)
+    updated = False
+
+    def resolve_entity(prefix: str) -> str | None:
+        candidates = sorted(
+            entity.entity_id
+            for entity in entity_registry.entities.values()
+            if entity.entity_id.startswith(prefix)
+        )
+        return candidates[0] if candidates else None
+
+    stale_mic = data.get(CONF_MIC_DEVICE)
+    if stale_mic and entity_registry.async_get(stale_mic) is None:
+        if mic_entity := resolve_entity(f"assist_satellite.vaca_{suffix}"):
+            data[CONF_MIC_DEVICE] = mic_entity
+            updated = True
+
+    stale_media = data.get(CONF_MEDIAPLAYER_DEVICE)
+    if stale_media and entity_registry.async_get(stale_media) is None:
+        if media_entity := resolve_entity(f"media_player.vaca_{suffix}"):
+            data[CONF_MEDIAPLAYER_DEVICE] = media_entity
+            updated = True
+
+    stale_music = data.get(CONF_MUSICPLAYER_DEVICE)
+    if stale_music and entity_registry.async_get(stale_music) is None:
+        if music_entity := resolve_entity(f"media_player.vaca_{suffix}"):
+            data[CONF_MUSICPLAYER_DEVICE] = music_entity
+            updated = True
+
+    if updated:
+        _LOGGER.info(
+            "Repairing stale VACA entity ids for %s using display device %s",
+            entry.title,
+            display_device,
+        )
+        hass.config_entries.async_update_entry(entry, data=data)
+
+    return entry
 
 
 def migrate_to_section(entry: VAConfigEntry, params: list[str]):
@@ -54,6 +111,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
             )
             return True
         return False
+
+    if entry.data[CONF_TYPE] != VAType.MASTER_CONFIG:
+        entry = _repair_stale_vaca_entity_ids(hass, entry)
 
     # Set runtime data
     set_runtime_data_for_config(hass, entry, is_master_entry)

--- a/custom_components/view_assist/__init__.py
+++ b/custom_components/view_assist/__init__.py
@@ -73,8 +73,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: VAConfigEntry):
 
 async def _async_update_listener(hass: HomeAssistant, config_entry: VAConfigEntry):
     """Handle config options update."""
-    # Reload the integration when the options change.
+    # Reload the updated entry when options change.
     hass.config_entries.async_schedule_reload(config_entry.entry_id)
+
+    # Dashboard options on the master entry flow down into every device entry.
+    # Reload those entries too so runtime dashboard paths stay in sync.
+    if config_entry.data[CONF_TYPE] == VAType.MASTER_CONFIG:
+        for entry in get_integration_entries(hass):
+            if entry.entry_id != config_entry.entry_id:
+                hass.config_entries.async_schedule_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: VAConfigEntry):

--- a/custom_components/view_assist/const.py
+++ b/custom_components/view_assist/const.py
@@ -48,7 +48,7 @@ JSMODULES = [
     {
         "name": "View Assist Helper",
         "filename": "view_assist.js",
-        "version": "1.0.25",
+        "version": "1.0.26",
     },
 ]
 # mins between checks for updated versions of dashboard and views

--- a/custom_components/view_assist/core/timers.py
+++ b/custom_components/view_assist/core/timers.py
@@ -1087,7 +1087,11 @@ class TimerManagerServices:
             time_type = "time"
         else:
             time_type = "interval"
-
+            
+        # Some STT add additional chars.  This removes those that add - or .
+        if timer_time:
+            timer_time = timer_time.replace("-", "").replace(".", "")
+        
         sentence, timer_info = await self.decode_time_sentence(
             timer_time, language=language, time_type=time_type
         )

--- a/custom_components/view_assist/core/timers.py
+++ b/custom_components/view_assist/core/timers.py
@@ -1084,8 +1084,6 @@ class TimerManagerServices:
         extra_data = call.data.get(ATTR_EXTRA)
 
         if timer_type and str(timer_type).lower() in ["reminder", "alarm"]:
-            # TODO: What is this for?
-            timer_type = TimerClass.REMINDER
             time_type = "time"
         else:
             time_type = "interval"

--- a/custom_components/view_assist/core/websocket.py
+++ b/custom_components/view_assist/core/websocket.py
@@ -148,6 +148,17 @@ class WebsocketListenerHandler:
                 f"{DOMAIN}_{self.config.entry_id}_event",
                 VAEvent(VAEventType.BROWSER_REGISTERED),
             )
+            current_path = self.config.runtime_data.extra_data.get("current_path")
+            if not current_path:
+                current_path = (
+                    self.config.runtime_data.runtime_config_overrides.home
+                    if self.config.runtime_data.runtime_config_overrides.home
+                    else self.config.runtime_data.dashboard.home
+                )
+            if current_path:
+                self._send_event(
+                    VAEvent(VAEventType.NAVIGATION, {"path": current_path})
+                )
         else:
             self._send_event(
                 VAEvent(VAEventType.BROWSER_UNREGISTERED),

--- a/custom_components/view_assist/devices/navigation.py
+++ b/custom_components/view_assist/devices/navigation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from asyncio import Task
 import logging
+import time
 
 import voluptuous as vol
 
@@ -12,7 +13,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv, selector
 from homeassistant.helpers.dispatcher import async_dispatcher_send, callback
 
-from ..const import ATTR_DEVICE, DEVICES, DOMAIN, VAMode  # noqa: TID252
+from ..const import ATTR_DEVICE, DEVICES, DOMAIN, VACA_DOMAIN, VAMode  # noqa: TID252
 from ..helpers import (  # noqa: TID252
     get_config_entry_by_entity_id,
     get_revert_settings_for_mode,
@@ -29,7 +30,9 @@ NAVIGATE_SERVICE_SCHEMA = vol.Schema(
             selector.EntitySelectorConfig(integration=DOMAIN)
         ),
         vol.Required(ATTR_PATH): str,
-        vol.Optional(ATTR_REVERT_TIMEOUT, default=20): cv.positive_int,
+        vol.Optional(ATTR_REVERT_TIMEOUT, default=20): vol.All(
+            vol.Coerce(int), vol.Range(min=0)
+        ),
     }
 )
 
@@ -58,6 +61,8 @@ class NavigationManager:
         self.revert_view_task: Task | None = None
         self.cycle_view_task: Task | None = None
         self.revert_timeout = config.runtime_data.default.view_timeout
+        self._last_vaca_forward_path: str = ""
+        self._last_vaca_forward_ts: float = 0.0
 
     async def async_setup_once(self) -> bool:
         """Set up navigation manager services that should only be registered once."""
@@ -76,6 +81,32 @@ class NavigationManager:
         """Unload the last instance of NavigationManager."""
         NavigationManagerServices(self.hass).unregister()
         return True
+
+    def _normalize_timeout(
+        self, timeout: int | float | str | None, default: int | None = None
+    ) -> int | None:
+        """Normalize timeout values coming from service data or internal callers."""
+        if timeout is None:
+            return default
+        try:
+            normalized = int(timeout)
+        except (TypeError, ValueError):
+            _LOGGER.warning(
+                "Invalid revert timeout %r for %s; using %s",
+                timeout,
+                self.config.runtime_data.core.name,
+                default,
+            )
+            return default
+        if normalized < 0:
+            _LOGGER.warning(
+                "Negative revert timeout %r for %s; using %s",
+                timeout,
+                self.config.runtime_data.core.name,
+                default,
+            )
+            return default
+        return normalized
 
     def browser_navigate(
         self,
@@ -117,6 +148,14 @@ class NavigationManager:
             VAEvent(VAEventType.CONFIG_UPDATE),
         )
 
+        # Resolve timeout now so it can be used for both VACA payload and revert scheduling.
+        requested_timeout = self._normalize_timeout(timeout, default=None)
+        effective_timeout = (
+            self.config.runtime_data.default.view_timeout
+            if requested_timeout is None
+            else requested_timeout
+        )
+
         # Send navigation event to VA JS Helper
         async_dispatcher_send(
             self.hass,
@@ -124,12 +163,20 @@ class NavigationManager:
             VAEvent(VAEventType.NAVIGATION, {"path": path}),
         )
 
+        # For VACA devices, also forward navigation through the VACA Wyoming
+        # channel so the companion app can wake/exit screensaver and navigate.
+        self._forward_navigation_to_vaca(
+            path,
+            is_revert_action=is_revert_action,
+            revert_timeout=effective_timeout,
+        )
+
         # If this was a revert action, end here
         if is_revert_action:
             return
 
         # If timeout set to 0, do not revert
-        if timeout == 0:
+        if requested_timeout == 0:
             return
 
         # If we have a hold path, revert to that instead of the default revert path
@@ -156,15 +203,62 @@ class NavigationManager:
 
         # Set revert action if required
         if revert and path != revert_path:
-            timeout = (
-                self.config.runtime_data.default.view_timeout
-                if timeout is None
-                else timeout
-            )
+            timeout = effective_timeout
             _LOGGER.debug("Adding revert to %s in %ss", revert_path, timeout)
             self.revert_view_task = self.hass.async_create_task(
                 self._display_revert_delay_task(path=revert_path, timeout=timeout)
             )
+
+    def _forward_navigation_to_vaca(
+        self,
+        path: str,
+        is_revert_action: bool = False,
+        revert_timeout: int | None = None,
+    ) -> None:
+        """Forward navigation action to VACA integration when applicable."""
+        try:
+            mic_entity_id = self.config.runtime_data.core.mic_device or ""
+            mic_entry = get_config_entry_by_entity_id(self.hass, mic_entity_id)
+            if not mic_entry or mic_entry.domain != VACA_DOMAIN:
+                return
+
+            vaca_data = self.hass.data.get(VACA_DOMAIN, {})
+            vaca_item = vaca_data.get(mic_entry.entry_id)
+            vaca_device = getattr(vaca_item, "device", None)
+            if vaca_device is None:
+                _LOGGER.debug("VACA device unavailable for navigation forward")
+                return
+
+            now = time.monotonic()
+            if (
+                self._last_vaca_forward_path == path
+                and (now - self._last_vaca_forward_ts) < 2.0
+            ):
+                _LOGGER.debug(
+                    "Skipping duplicate VACA navigation forward path=%s dt=%.3fs",
+                    path,
+                    now - self._last_vaca_forward_ts,
+                )
+                return
+
+            # Wake first for direct navigations so screensaver can be exited cleanly.
+            if not is_revert_action:
+                vaca_device.send_custom_action("screen-wake")
+            payload: dict[str, int | str] = {"path": path}
+            if is_revert_action:
+                payload["revert_timeout"] = 0
+            elif revert_timeout is not None:
+                payload["revert_timeout"] = int(revert_timeout)
+            vaca_device.send_custom_action("navigate", payload)
+            self._last_vaca_forward_path = path
+            self._last_vaca_forward_ts = now
+            _LOGGER.debug(
+                "Forwarded navigation to VACA: %s (revert_timeout=%s)",
+                path,
+                revert_timeout,
+            )
+        except Exception as ex:  # noqa: BLE001
+            _LOGGER.warning("Failed to forward navigation to VACA: %s", ex)
 
     def navigate_home(self):
         """Navigate browser to home view."""
@@ -181,8 +275,9 @@ class NavigationManager:
 
     async def _display_revert_delay_task(self, path: str, timeout: int = 0):
         """Display revert function.  To be called from task."""
-        if timeout:
-            await asyncio.sleep(timeout)
+        normalized_timeout = self._normalize_timeout(timeout, default=0)
+        if normalized_timeout:
+            await asyncio.sleep(normalized_timeout)
             self.browser_navigate(path=path, is_revert_action=True)
 
     def cancel_display_revert_task(self):
@@ -235,6 +330,7 @@ class NavigationManagerServices:
             DOMAIN,
             "navigate",
             self._handle_navigate,
+            schema=NAVIGATE_SERVICE_SCHEMA,
         )
 
     def unregister(self):

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -677,12 +677,18 @@ class ViewAssist {
   }
 
   process_config(event, payload) {
-    let reload = false;
-    const old_config = this.variables?.config
+      let reload = false;
+      const old_config = this.variables?.config
+      const currentPath = window.location.pathname || "";
+      const previousHomePath =
+        old_config?.home ||
+        localStorage.getItem("view_assist_home") ||
+        "/view-assist/clock";
+      const homePath = payload.home || "/view-assist/clock";
 
-    if (event == "registered") {
-      reload = true;
-    }
+      if (event == "registered") {
+        reload = true;
+      }
 
     // Entity id changed
     if (payload.entity_id && payload.entity_id != localStorage.getItem("view_assist_sensor")) {
@@ -691,30 +697,53 @@ class ViewAssist {
       reload = true;
     }
 
-    // Set variables to payload
-    this.variables.config = payload
+      // Set variables to payload
+      this.variables.config = payload
+      localStorage.setItem("view_assist_home", homePath);
 
-    if (!payload.mimic_device) {
-      // On register, only force home when we are at a neutral path.
-      // This prevents registered events from overriding explicit navigation
-      // (for example, an idle-triggered screensaver path).
-      if (reload) {
-        const currentPath = window.location.pathname || "";
-        const homePath = payload.home || "/view-assist/clock";
-        const atNeutralPath =
-          currentPath === "/" ||
-          currentPath === "/auth/authorize" ||
-          currentPath === homePath;
-        if (atNeutralPath) {
-          this.browser_navigate(homePath);
-        } else {
+      if (
+        !payload.mimic_device &&
+        previousHomePath !== homePath &&
+        currentPath === previousHomePath
+      ) {
           console.debug(
-            "ViewAssist - registered event keeping current path:",
-            currentPath
-          );
+            "ViewAssist - home path changed, navigating current home path:",
+          previousHomePath,
+          "->",
+          homePath
+        );
+        this.browser_navigate(homePath);
+        return;
+      }
+
+      if (!payload.mimic_device) {
+        // On register, only force home when we are at a neutral path.
+        // This prevents registered events from overriding explicit navigation
+        // (for example, an idle-triggered screensaver path).
+        if (reload) {
+          const atNeutralPath =
+            currentPath === "/" ||
+            currentPath === "/auth/authorize" ||
+            currentPath === homePath;
+          const atInternalViewAssistPath =
+            currentPath.startsWith("/view-assist/") &&
+            currentPath !== homePath;
+          if (atNeutralPath || atInternalViewAssistPath) {
+            console.debug(
+              "ViewAssist - registered event syncing path:",
+              currentPath,
+              "->",
+              homePath
+            );
+            this.browser_navigate(homePath);
+          } else {
+            console.debug(
+              "ViewAssist - registered event keeping current path:",
+              currentPath
+            );
+          }
         }
       }
-    }
   }
 
   async set_time_delta() {

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -523,20 +523,49 @@ class ViewAssist {
   }
 
   get_browser_id() {
-    // Create a browser id if not already set
-    if (!localStorage.getItem("view_assist_browser_id")) {
-      // Test if VA Companion App is installed and get uuid from that
-      let browser_id = '';
-      try {
-        browser_id = `va-${ViewAssistApp.getViewAssistCAUUID()}`;
-      } catch (e) {
-        const s4 = () => { return Math.floor((1 + Math.random()) * 100000).toString(16).substring(1); };
-        browser_id = `va-${s4()}${s4()}-${s4()}${s4()}`
+    const native_browser_id = this.get_native_browser_id();
+    const stored_browser_id = localStorage.getItem("view_assist_browser_id");
+
+    // If running inside the companion app, always prefer the stable app UUID.
+    // This repairs stale/random browser IDs left behind by unhealthy sessions.
+    if (native_browser_id) {
+      if (stored_browser_id !== native_browser_id) {
+        console.debug(
+          "ViewAssist - replacing stale browser id",
+          stored_browser_id,
+          "with native id",
+          native_browser_id
+        );
+        localStorage.setItem("view_assist_browser_id", native_browser_id);
+        localStorage.removeItem("view_assist_status");
+        localStorage.removeItem("view_assist_sensor");
+        localStorage.removeItem("view_assist_mimic_device");
       }
+      return native_browser_id;
+    }
+
+    // Outside the companion app, keep the browser-local id.
+    if (!stored_browser_id) {
+      const s4 = () => { return Math.floor((1 + Math.random()) * 100000).toString(16).substring(1); };
+      const browser_id = `va-${s4()}${s4()}-${s4()}${s4()}`
       localStorage.setItem("view_assist_browser_id", browser_id);
       return browser_id
     }
-    return localStorage.getItem("view_assist_browser_id");
+    return stored_browser_id;
+  }
+
+  get_native_browser_id() {
+    try {
+      if (typeof ViewAssistApp !== "undefined" && ViewAssistApp.getViewAssistCAUUID) {
+        const uuid = ViewAssistApp.getViewAssistCAUUID();
+        if (uuid) {
+          return `va-${uuid}`;
+        }
+      }
+    } catch (e) {
+      // No native app bridge available; fall back to browser-local ID.
+    }
+    return null;
   }
 
   async connect(attempts = 1) {
@@ -606,6 +635,21 @@ class ViewAssist {
         this.variables.config = {};
         this.variables.registered = false;
         await this.hide_sections(this.variables.registered);
+        {
+          const native_browser_id = this.get_native_browser_id();
+          if (native_browser_id && this.variables.browser_id !== native_browser_id) {
+            console.debug(
+              "ViewAssist - unregistered stale browser id, healing to native id:",
+              this.variables.browser_id,
+              "->",
+              native_browser_id
+            );
+            localStorage.setItem("view_assist_browser_id", native_browser_id);
+            this.variables.browser_id = native_browser_id;
+            setTimeout(() => this.connect(), 1000);
+            break;
+          }
+        }
         setTimeout(() => this. display_browser_id(), 2000);
         break;
       case "config_update":

--- a/custom_components/view_assist/js_modules/view_assist.js
+++ b/custom_components/view_assist/js_modules/view_assist.js
@@ -1,6 +1,6 @@
-import { timerCards } from "./timers.js?v=1.0.25";
+import { timerCards } from "./timers.js?v=1.0.26";
 
-const version = "1.0.25"
+const version = "1.0.26"
 const TIMEOUT_ERROR = "SELECTTREE-TIMEOUT";
 
 export async function await_element(el, hard = false) {
@@ -651,9 +651,24 @@ class ViewAssist {
     this.variables.config = payload
 
     if (!payload.mimic_device) {
-      // On register, go to default page
+      // On register, only force home when we are at a neutral path.
+      // This prevents registered events from overriding explicit navigation
+      // (for example, an idle-triggered screensaver path).
       if (reload) {
-        this.browser_navigate(payload.home);
+        const currentPath = window.location.pathname || "";
+        const homePath = payload.home || "/view-assist/clock";
+        const atNeutralPath =
+          currentPath === "/" ||
+          currentPath === "/auth/authorize" ||
+          currentPath === homePath;
+        if (atNeutralPath) {
+          this.browser_navigate(homePath);
+        } else {
+          console.debug(
+            "ViewAssist - registered event keeping current path:",
+            currentPath
+          );
+        }
       }
     }
   }

--- a/custom_components/view_assist/manifest.json
+++ b/custom_components/view_assist/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/dinki/view_assist_integration/issues",
   "requirements": ["wordtodigits==1.0.2", "beautifulsoup4>=4.11.0"],
-  "version": "2026.2.0"
+  "version": "2026.3.0"
 }

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -278,7 +278,9 @@ class ViewAssistSensor(RestoreSensor):
             "mode": d.default.mode,
             "view_timeout": d.default.view_timeout,
             "weather_entity": d.default.weather_entity,
-            "screen_mode": self.config.runtime_data.dashboard.display_settings.screen_mode,
+            "screen_mode": d.dashboard.display_settings.screen_mode,
+            "home_screen": d.runtime_config_overrides.home if
+            d.runtime_config_overrides.home else d.dashboard.home,
         }
 
     def _get_active_overrides_attributes(self) -> dict[str, Any]:

--- a/custom_components/view_assist/sensor.py
+++ b/custom_components/view_assist/sensor.py
@@ -103,6 +103,8 @@ class ViewAssistSensor(RestoreSensor):
                     "use_24_hour_time", "background", "mode", "view_timeout", 
                     "weather_entity", "screen_mode", "do_not_disturb", 
                     "use_announce",
+                    "home_screen",
+                    "current_path",
 
                     # Generated/ephemeral
                     "last_updated", "active_overrides",

--- a/custom_components/view_assist/translations/sr-Latn.json
+++ b/custom_components/view_assist/translations/sr-Latn.json
@@ -1,0 +1,271 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Uređaj je već konfigurisan",
+      "reconfigure_successful": "Ponavljena konfiguracija je uspešna",
+      "already_in_progress": "Podešavanje za ovu integraciju je već u toku"
+    },
+    "error": {
+      "cannot_connect": "Neuspešno povezivanje",
+      "invalid_auth": "Neispravna autentikacija",
+      "invalid_settings": "Neispravna podešavanja",
+      "unknown": "Neočekivana greška"
+    },
+    "step": {
+      "master_config": {
+        "title": "Master konfiguracija",
+        "description": "Ovo dodaje master instancu konfiguracije za View Assist\n\n Mora biti dodata pre nego što podesite bilo koje View Assist uređaje ako je nova instalacija ili pre dodavanja dodatnih View Assist uređaja ako je postojeća instalacija\n\n Možda ćete morati da osvežite postojeće View Assist uređaje da biste omogućili punu funkcionalnost"
+      },
+      "options": {
+        "title": "Konfigurišite View Assist uređaj",
+        "data": {
+          "name": "Ime satelita",
+          "mic_device": "Mikrofon uređaj",
+          "mediaplayer_device": "Medija plejer uređaj",
+          "musicplayer_device": "Muzički plejer uređaj",
+          "display_device": "Uređaj za prikaz",
+          "intent_device": "Intent uređaj (opciono)",
+          "orientation_sensor": "Senzor orijentacije (opciono)",
+          "dev_mimic": "Imitirani uređaj za razvoj prikaza"
+        },
+        "data_description": {
+          "name": "Ime View Assist satelita",
+          "mic_device": "Mikrofon uređaj za ovaj satelit",
+          "mediaplayer_device": "Medija plejer uređaj za ovaj satelit",
+          "musicplayer_device": "Muzički plejer uređaj za ovaj satelit",
+          "display_device": "Uređaj za prikaz za ovaj satelit",
+          "intent_device": "Uređaj koji obezbeđuje intent podatke za ovaj satelit",
+          "orientation_sensor": "Senzor koji prijavljuje orijentaciju uređaja (portret/pejzaž)",
+          "dev_mimic": "Koristite ovaj uređaj za razvoj prikaza na drugom računaru"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Konfiguracija",
+        "description": "Izaberite koje opcije želite da izmenite",
+        "menu_options": {
+          "integration_options": "Opcije integracije",
+          "main_config": "Osnovna konfiguracija uređaja",
+          "dashboard_options": "Opcije kontrolne table",
+          "default_options": "Podrazumevane opcije",
+          "developer_options": "Opcije za programere"
+        }
+      },
+      "main_config": {
+        "title": "{name} Osnovna konfiguracija uređaja",
+        "description": "",
+        "data": {
+          "name": "Ime satelita",
+          "mic_device": "Mikrofon uređaj",
+          "mediaplayer_device": "Medija plejer uređaj",
+          "musicplayer_device": "Muzički plejer uređaj",
+          "display_device": "Uređaj za prikaz",
+          "intent_device": "Intent uređaj (opciono)",
+          "orientation_sensor": "Senzor orijentacije (opciono)",
+          "dev_mimic": "Mimik za razvoj prikaza"
+        },
+        "data_description": {
+          "name": "Ime View Assist satelita",
+          "mic_device": "Mikrofon uređaj za ovaj satelit",
+          "mediaplayer_device": "Medija plejer uređaj za ovaj satelit",
+          "musicplayer_device": "Muzički plejer uređaj za ovaj satelit",
+          "intent_device": "Uređaj koji obezbeđuje intent podatke za ovaj satelit",
+          "orientation_sensor": "Senzor koji prijavljuje orijentaciju uređaja (portret/pejzaž)",
+          "display_device": "Uređaj za prikaz za ovaj satelit",
+          "dev_mimic": "Koristite ovaj uređaj za razvoj prikaza na drugom računaru"
+        }
+      },
+      "dashboard_options": {
+        "title": "{name} Opcije kontrolne table",
+        "description": "{description}",
+        "data": {
+          "dashboard": "Kontrolna tabla",
+          "home": "Početni ekran",
+          "music": "Muzički prikaz",
+          "intent": "Intent prikaz",
+          "list_view": "Prikaz liste"
+        },
+        "data_description": {
+          "dashboard": "Osnovna kontrolna tabla za View Assist (ne uključivati završnu kosu crtu)",
+          "home": "Ekran na koji se vraća nakon isteka vremena",
+          "music": "Prikaz na koji se vraća u muzičkom režimu",
+          "intent": "Prikaz koji se koristi za podrazumevane HA akcije za prikaz tih entiteta",
+          "list_view": "Prikaz koji se prikazuje prilikom ažuriranja liste"
+        },
+        "sections": {
+          "background_settings": {
+            "name": "Podešavanja pozadine",
+            "description": "Opcije za sliku pozadine",
+            "data": {
+              "background_mode": "Izvor slike pozadine",
+              "background": "Podrazumevana pozadina",
+              "rotate_background_path": "Putanja ili URL slike",
+              "rotate_background_linked_entity": "Povezani entitet",
+              "rotate_background_interval": "Interval rotiranja"
+            },
+            "data_description": {
+              "background": "URL podrazumevane slike pozadine",
+              "rotate_background_path": "Putanja unutar config/view_assist za učitavanje slika u lokalnim režimima fajlova. URL za učitavanje slika u URL režimu",
+              "rotate_background_linked_entity": "View Assist entitet za povezivanje pozadine",
+              "rotate_background_interval": "Interval u minutima za rotiranje pozadine"
+            }
+          },
+          "display_settings": {
+            "name": "Podešavanja prikaza",
+            "description": "Opcije za uređaj za prikaz",
+            "data": {
+              "assist_prompt": "Assist upit",
+              "font_style": "Stil fonta",
+              "status_icons_size": "Veličina ikone statusa",
+              "status_icons": "Ikone za pokretanje",
+              "menu_config": "Konfiguracija menija",
+              "menu_items": "Stavke menija",
+              "menu_timeout": "Tajmaut menija",
+              "time_format": "Format vremena",
+              "screen_mode": "Prikaži/sakrij zaglavlje i bočni meni",
+              "cycle_views": "Ciklični prikazi"
+            },
+            "data_description": {
+              "assist_prompt": "Stil Assist obaveštenja za detekciju reči za buđenje i obradu intenta",
+              "font_style": "Podrazumevani font za ovaj satelitski uređaj. Naziv fonta mora tačno da se poklapa i da bude dostupan",
+              "status_icons_size": "Veličina ikona u prikazu ikona statusa",
+              "status_icons": "Napredna opcija! Lista prilagođenih ikona za pokretanje koja se podešava pri pokretanju. Ne menjajte ako niste sigurni šta radite",
+              "menu_config": "Konfigurišite ponašanje menija",
+              "menu_items": "Lista stavki koje će se prikazati u meniju kada je aktiviran",
+              "menu_timeout": "Vreme u sekundama pre automatskog zatvaranja menija (0 za onemogućavanje)",
+              "time_format": "Postavlja format prikaza vremena",
+              "screen_mode": "Prikaži ili sakrij zaglavlje i bočni meni",
+              "cycle_views": "Lista stavki koje će se prikazivati u ciklus režimu"
+            }
+          }
+        }
+      },
+      "default_options": {
+        "title": "{name} Podrazumevane opcije",
+        "description": "{description}",
+        "data": {
+          "weather_entity": "Entitet vremena za prikaz prognoze",
+          "mic_type": "Integracija koja obrađuje ulaz sa mikrofona",
+          "mode": "Podrazumevani režim",
+          "view_timeout": "Tajmaut prikaza",
+          "do_not_disturb": "Omogući Ne uznemiravaj pri pokretanju",
+          "use_announce": "Onemogući najave na ovom uređaju",
+          "micunmute": "Uključi mikrofon pri pokretanju/restartu HA",
+          "ducking_volume": "Procenat smanjenja jačine zvuka",
+          "music_mode_auto": "Automatski muzički režim",
+          "music_mode_timeout": "Tajmaut muzičkog režima"
+        },
+        "data_description": {
+          "mode": "Podrazumevani režim za ovaj satelitski uređaj",
+          "view_timeout": "Podrazumevana vrednost tajmauta u sekundama pre povratka na podrazumevani prikaz",
+          "do_not_disturb": "Podrazumevano stanje Ne uznemiravaj pri restartu HA",
+          "use_announce": "Neki media playeri, kao BrowserMod, ne mogu da koriste Home Assistant announce funkciju dok mediji sviraju. Ova opcija omogućava isključivanje announce poruka ako nastanu problemi. Podrazumevano je uključeno.",
+          "micunmute": "Korisno za Stream Assist uređaje",
+          "ducking_volume": "Smanji jačinu medija za ovaj procenat kada je Assist aktivan",
+          "music_mode_auto": "Automatski uđi u muzički režim kada muzički plejer počne reprodukciju",
+          "music_mode_timeout": "Vreme u sekundama pre automatskog izlaska iz muzičkog režima nakon zaustavljanja muzike (0 = onemogućeno)"
+        }
+      },
+      "integration_options": {
+        "title": "{name} Opcije integracije",
+        "data": {
+          "enable_updates": "Omogući obaveštenja o ažuriranjima",
+          "translation_engine": "Prevodilačka mašina"
+        },
+        "data_description": {
+          "enable_updates": "Omogućite ili onemogućite obaveštenja o ažuriranjima za kontrolnu tablu, prikaze i šablone",
+          "translation_engine": "Prevodilačka mašina koja se koristi za tajmere (eksperimentalno)"
+        }
+      },
+      "developer_options": {
+        "title": "{name} Opcije za programere",
+        "data": {
+          "developer_device": "Uređaj za razvoj",
+          "developer_mimic_device": "Uređaj za imitiranje"
+        },
+        "data_description": {
+          "developer_device": "Browser ID uređaja koji želite da koristite za razvoj",
+          "developer_mimic_device": "Uređaj koji će se imitirati za razvoj"
+        }
+      }
+    }
+  },
+  "selector": {
+    "type_selector": {
+      "options": {
+        "vaca": "View Assist Companion App uređaj",
+        "view_audio": "View Assist uređaj sa prikazom",
+        "audio_only": "View Assist uređaj bez prikaza"
+      }
+    },
+    "assist_prompt_selector": {
+      "options": {
+        "blur_pop_up": "Zamućuje ekran i prikazuje iskačući prozor",
+        "flashing_bar": "Treptajuća traka na dnu",
+        "kitt_bar": "KITT stil trake na dnu"
+      }
+    },
+    "status_icons_size_selector": {
+      "options": {
+        "6vw": "Mala",
+        "7vw": "Srednja",
+        "8vw": "Velika"
+      }
+    },
+    "menu_config_selector": {
+      "options": {
+        "menu_disabled": "Meni onemogućen",
+        "menu_enabled_button_visible": "Meni omogućen, dugme vidljivo",
+        "menu_enabled_button_hidden": "Meni omogućen, dugme skriveno"
+      }
+    },
+    "mic_type_selector": {
+      "options": {
+        "home_assistant_voice_satellite": "Home Assistant Voice Satellite",
+        "hassmic": "HassMic",
+        "stream_assist": "Stream Assist"
+      }
+    },
+    "display_type_selector": {
+      "options": {
+        "browser_mod": "BrowserMod",
+        "remote_assist_display": "Remote Assist Display",
+        "stream_assist": "Stream Assist"
+      }
+    },
+    "rotate_backgound_source_selector": {
+      "options": {
+        "default_background": "Podrazumevana pozadina",
+        "local_sequence": "Sekvencijalna slika iz lokalne putanje",
+        "local_random": "Slučajna slika iz lokalne putanje",
+        "download": "Slučajna slika sa unsplash.com",
+        "custom_url": "Slika sa prilagođenog URL-a",
+        "link_to_entity": "Ogledalo drugog View Assist uređaja"
+      }
+    },
+    "menu_icons_selector": {
+      "options": {}
+    },
+    "lookup_selector": {
+      "options": {
+        "hour_12": "12 sati",
+        "hour_24": "24 sata",
+        "on": "Uključeno",
+        "off": "Isključeno",
+        "hide_header_sidebar": "Sakrij zaglavlje i bočni meni",
+        "hide_header": "Sakrij zaglavlje",
+        "hide_sidebar": "Sakrij bočni meni",
+        "no_hide": "Ne sakrivaj elemente"
+      }
+    }
+  },
+  "issues": {
+    "no_resource_version": {
+      "title": "Rešite probleme sa verzijom resursa View Assist",
+      "description": "Pomoćni plugin View Assist resursa nema identifikator verzije. Ovo može uzrokovati da se ne koristi najnovija verzija. Uklonite resurs i ponovo pokrenite Home Assistant da biste rešili problem."
+    }
+  }
+}

--- a/custom_components/view_assist/translations/sr.json
+++ b/custom_components/view_assist/translations/sr.json
@@ -1,0 +1,271 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Уређај је већ конфигурисан",
+      "reconfigure_successful": "Поновна конфигурација је успешна",
+      "already_in_progress": "Подешавање за ову интеграцију је већ у току"
+    },
+    "error": {
+      "cannot_connect": "Неуспешно повезивање",
+      "invalid_auth": "Неисправна аутентификација",
+      "invalid_settings": "Неисправна подешавања",
+      "unknown": "Неочекивана грешка"
+    },
+    "step": {
+      "master_config": {
+        "title": "Мастер конфигурација",
+        "description": "Ово додаје мастер инстанцу конфигурације за „View Assist\n\n” Мора бити додата пре него што подесите било које „View Assist” уређаје ако је нова инсталација или пре додавања додатних „View Assist” уређаја ако је постојећа инсталација\n\n Можда ћете морати да освежите постојеће „View Assist” уређаје да бисте омогућили пуну функционалност"
+      },
+      "options": {
+        "title": "Конфигуришите „View Assist” уређај",
+        "data": {
+          "name": "Име сателита",
+          "mic_device": "Микрофон уређај",
+          "mediaplayer_device": "Медија плејер уређај",
+          "musicplayer_device": "Музички плејер уређај",
+          "display_device": "Уређај за приказ",
+          "intent_device": "Уређај за интент (опционо)",
+          "orientation_sensor": "Сензор оријентације (опционо)",
+          "dev_mimic": "Имитирани уређај за развој приказа"
+        },
+        "data_description": {
+          "name": "Име „View Assist” сателита",
+          "mic_device": "Микрофонски уређај за овај сателит",
+          "mediaplayer_device": "Медија плејер уређај за овај сателит",
+          "musicplayer_device": "Музички плејер уређај за овај сателит",
+          "display_device": "Уређај за приказ за овај сателит",
+          "intent_device": "Уређај који обезбеђује интент податке за овај сателит",
+          "orientation_sensor": "Сензор који пријављује оријентацију уређаја (портрет/пехзаж)",
+          "dev_mimic": "Користите овај уређај за развој приказа на другом рачунару"
+        }
+      }
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Конфигурација",
+        "description": "Изаберите које опције желите да измените",
+        "menu_options": {
+          "integration_options": "Опције интеграције",
+          "main_config": "Основна конфигурација уређаја",
+          "dashboard_options": "Опције контролне табле",
+          "default_options": "Подразумеване опције",
+          "developer_options": "Опције за програмере"
+        }
+      },
+      "main_config": {
+        "title": "{name} Основна конфигурација уређаја",
+        "description": "",
+        "data": {
+          "name": "Име сателита",
+          "mic_device": "Микрофон уређај",
+          "mediaplayer_device": "Медија плејер уређај",
+          "musicplayer_device": "Музички плејер уређај",
+          "display_device": "Уређај за приказ",
+          "intent_device": "Уређај за интент (опционо)",
+          "orientation_sensor": "Сензор оријентације (опционо)",
+          "dev_mimic": "Мимик за развој приказа"
+        },
+        "data_description": {
+          "name": "Име „View Assist” сателита",
+          "mic_device": "Микрофонски уређај за овај сателит",
+          "mediaplayer_device": "Медија плејер уређај за овај сателит",
+          "musicplayer_device": "Музички плејер уређај за овај сателит",
+          "intent_device": "Уређај који обезбеђује интент податке за овај сателит",
+          "orientation_sensor": "Сензор који пријављује оријентацију уређаја (портрет/пејзаж)",
+          "display_device": "Уређај за приказ за овај сателит",
+          "dev_mimic": "Користите овај уређај за развој приказа на другом рачунару"
+        }
+      },
+      "dashboard_options": {
+        "title": "{name} Опције контролне табле",
+        "description": "{description}",
+        "data": {
+          "dashboard": "Контролна табла",
+          "home": "Почетни екран",
+          "music": "Музички приказ",
+          "intent": "Интент приказ",
+          "list_view": "Приказ листе"
+        },
+        "data_description": {
+          "dashboard": "Основна контролна табла за „View Assist” (не укључивати завршну косу црту)",
+          "home": "Екран на који се враћа након истека времена",
+          "music": "Приказ на који се враћа у музичком режиму",
+          "intent": "Приказ који се користи за подразумеване „HA” акције за приказ тих ентитета",
+          "list_view": "Приказ који се приказује приликом ажурирања листе"
+        },
+        "sections": {
+          "background_settings": {
+            "name": "Подешавања позадине",
+            "description": "Опције за слику позадине",
+            "data": {
+              "background_mode": "Извор слике позадине",
+              "background": "Подразумевана позадина",
+              "rotate_background_path": "Путања или URL слике",
+              "rotate_background_linked_entity": "Повезани ентитет",
+              "rotate_background_interval": "Интервал ротирања"
+            },
+            "data_description": {
+              "background": "„URL” подразумеване слике позадине",
+              "rotate_background_path": "Путања унутар „config/view_assist” за учитавање слика у локалним режимима датотека. „URL” за учитавање слика у „URL” режиму",
+              "rotate_background_linked_entity": "„View Assist” ентитет за повезивање позадине",
+              "rotate_background_interval": "Интервал у минутима за ротирање позадине"
+            }
+          },
+          "display_settings": {
+            "name": "Подешавања приказа",
+            "description": "Опције за уређај за приказ",
+            "data": {
+              "assist_prompt": "„Assist” упит",
+              "font_style": "Стил фонта",
+              "status_icons_size": "Величина иконе статуса",
+              "status_icons": "Иконе за покретање",
+              "menu_config": "Конфигурација менија",
+              "menu_items": "Ставке менија",
+              "menu_timeout": "Тајмаут менија",
+              "time_format": "Формат времена",
+              "screen_mode": "Прикажи/сакриј заглавље и бочни мени",
+              "cycle_views": "Циклични прикази"
+            },
+            "data_description": {
+              "assist_prompt": "Стил „Assist” обавештења за детекцију речи за буђење и обраду интента",
+              "font_style": "Подразумевани фонт за овај сателитски уређај. Назив фонта мора тачно да се поклапа и да буде доступан",
+              "status_icons_size": "Величина икона у приказу икона статуса",
+              "status_icons": "Напредна опција! Листа прилагођених икона за покретање која се подешава при покретању. Не мењајте ако нисте сигурни шта радите",
+              "menu_config": "Конфигуришите понашање менија",
+              "menu_items": "Листа ставки које ће се приказати у менију када је активиран",
+              "menu_timeout": "Време у секундама пре аутоматског затварања менија (0 за онемогућавање)",
+              "time_format": "Поставља формат приказа времена",
+              "screen_mode": "Прикажи или сакриј заглавље и бочни мени",
+              "cycle_views": "Листа ставки које ће се приказивати у циклус режиму"
+            }
+          }
+        }
+      },
+      "default_options": {
+        "title": "{name} Подразумеване опције",
+        "description": "{description}",
+        "data": {
+          "weather_entity": "Ентитет времена за приказ прогнозе",
+          "mic_type": "Интеграција која обрађује улаз са микрофона",
+          "mode": "Подразумевани режим",
+          "view_timeout": "Тајмаут приказа",
+          "do_not_disturb": "Омогући Не узнемиравај режим при покретању",
+          "use_announce": "Онемогући најаве на овом уређају",
+          "micunmute": "Укључи микрофон при покретању/рестарту „HA”",
+          "ducking_volume": "Проценат смањења јачине звука",
+          "music_mode_auto": "Аутоматски музички режим",
+          "music_mode_timeout": "Тајмаут музичког режима"
+        },
+        "data_description": {
+          "mode": "Подразумевани режим за овај сателитски уређај",
+          "view_timeout": "Подразумевана вредност тајмаута у секундама пре повратка на подразумевани приказ",
+          "do_not_disturb": "Подразумевано стање Не узнемиравај при рестарту „HA”",
+          "use_announce": "Неки медија плејери, као „BrowserMod”, не могу да користе „Home Assistant announce” функцију док медији свирају. Ова опција омогућава искључивање „announce” порука ако настану проблеми. Подразумевано је укључено.",
+          "micunmute": "Корисно за „Stream Assist” уређаје",
+          "ducking_volume": "Смањи јачину медија за овај проценат када је „Assist” активан",
+          "music_mode_auto": "Аутоматски ући у музички режим када музички плејер почне репродукцију",
+          "music_mode_timeout": "Време у секундама пре аутоматског изласка из музичког режима након заустављања музике (0 = онемогућено)"
+        }
+      },
+      "integration_options": {
+        "title": "{name} Опције интеграције",
+        "data": {
+          "enable_updates": "Омогући обавештења о ажурирањима",
+          "translation_engine": "Преводилачка машина"
+        },
+        "data_description": {
+          "enable_updates": "Омогућите или онемогућите обавештења о ажурирањима за контролну таблу, приказе и шаблоне",
+          "translation_engine": "Преводилачка машна која се користи за тајмере (експериментално)"
+        }
+      },
+      "developer_options": {
+        "title": "{name} Опције за програмере",
+        "data": {
+          "developer_device": "Уређај за развој",
+          "developer_mimic_device": "Уређај за имитирање"
+        },
+        "data_description": {
+          "developer_device": "„Browser ID” уређаја који желите да користите за развој",
+          "developer_mimic_device": "Уређај који ће се имитирати за развој"
+        }
+      }
+    }
+  },
+  "selector": {
+    "type_selector": {
+      "options": {
+        "vaca": "„View Assist Companion App” уређај",
+        "view_audio": "„View Assist” уређај са приказом",
+        "audio_only": "„View Assist” уређај без приказа"
+      }
+    },
+    "assist_prompt_selector": {
+      "options": {
+        "blur_pop_up": "Замућује екран и приказује искачући прозор",
+        "flashing_bar": "Трептајућа трака на дну",
+        "kitt_bar": "„KITT” стил траке на дну"
+      }
+    },
+    "status_icons_size_selector": {
+      "options": {
+        "6vw": "Мала",
+        "7vw": "Средња",
+        "8vw": "Велика"
+      }
+    },
+    "menu_config_selector": {
+      "options": {
+        "menu_disabled": "Мени онемогућен",
+        "menu_enabled_button_visible": "Мени омогућен, дугме видљиво",
+        "menu_enabled_button_hidden": "Мени омогућен, дугме скривено"
+      }
+    },
+    "mic_type_selector": {
+      "options": {
+        "home_assistant_voice_satellite": "„Home Assistant Voice Satellite”",
+        "hassmic": "„HassMic”",
+        "stream_assist": "„Stream Assist”"
+      }
+    },
+    "display_type_selector": {
+      "options": {
+        "browser_mod": "„BrowserMod”",
+        "remote_assist_display": "„Remote Аssist Display”",
+        "stream_assist": "„Stream Assist”"
+      }
+    },
+    "rotate_backgound_source_selector": {
+      "options": {
+        "default_background": "Подразумевана позадина",
+        "local_sequence": "Секвенцијална слика из локалне путање",
+        "local_random": "Случајна слика из локалне путање",
+        "download": "Случајна слика са „unsplash.com”",
+        "custom_url": "Слика са прилагођеног „URL”-а",
+        "link_to_entity": "Огледало другог „View Assist” уређаја"
+      }
+    },
+    "menu_icons_selector": {
+      "options": {}
+    },
+    "lookup_selector": {
+      "options": {
+        "hour_12": "12 сати",
+        "hour_24": "24 сата",
+        "on": "Укључено",
+        "off": "Искључено",
+        "hide_header_sidebar": "Сакриј заглавље и бочни мени",
+        "hide_header": "Сакриј заглавље",
+        "hide_sidebar": "Сакриј бочни мени",
+        "no_hide": "Не сакривај елементе"
+      }
+    }
+  },
+  "issues": {
+    "no_resource_version": {
+      "title": "Решите проблеме са верзијом ресурса „View Assist”",
+      "description": "Помоћни плагин „View Assist” ресурса нема идентификатор верзије. Ово може узроковати да се не користи најновија верзија. Уклоните ресурс и поново покрените „Home Assistant” да бисте решили проблем."
+    }
+  }
+}

--- a/custom_components/view_assist/translations/timers/ro.json
+++ b/custom_components/view_assist/translations/timers/ro.json
@@ -1,0 +1,79 @@
+{
+  "decimal_separator": ",",
+
+  "numbers": {
+    "zero": "zero",
+    "one": "unu",
+    "two": "doi",
+    "three": "trei",
+    "four": "patru",
+    "five": "cinci",
+    "six": "șase",
+    "seven": "șapte",
+    "eight": "opt",
+    "nine": "nouă",
+    "ten": "zece",
+    "eleven": "unsprezece",
+    "twelve": "doisprezece",
+    "thirteen": "treisprezece",
+    "fourteen": "paisprezece",
+    "fifteen": "cincisprezece",
+    "sixteen": "șaisprezece",
+    "seventeen": "șaptesprezece",
+    "eighteen": "optsprezece",
+    "nineteen": "nouăsprezece",
+    "twenty": "douăzeci",
+    "thirty": "treizeci",
+    "forty": "patruzeci",
+    "fifty": "cincizeci",
+    "sixty": "șaizeci",
+    "seventy": "șaptezeci",
+    "eighty": "optzeci",
+    "ninety": "nouăzeci"
+  },
+
+  "days": {
+    "today": ["azi", "astăzi"],
+    "tomorrow": ["mâine"],
+    "day_after_tomorrow": ["poimâine"]
+  },
+
+  "structures": {
+    "basic_time": [
+      "ora {hours}:{minutes}",
+      "{hours}:{minutes}",
+      "ora {hours}:{minutes} de minute",
+      "{hours}:{minutes} de minute"
+    ],
+
+    "advanced_time": [
+      "{day} la {basic_time}",
+      "{day} {basic_time}",
+      "pentru {day} la {basic_time}"
+    ],
+
+    "advanced_interval": [
+      "{hours} ore și {minutes} minute",
+      "{minutes} minute și {seconds} secunde"
+    ]
+  },
+
+    "responses": {
+    "timer_set": "Timer setat pentru {time}",
+    "timer_named_set": "Timerul {name} a fost setat pentru {time}",
+
+    "timer_none": "Nu există timere setate",
+    "timer_list": "Ai următoarele timere setate: {timers}",
+
+    "timer_cancelled": "Timerul {name} a fost anulat",
+    "timer_not_found": "Nu s-a găsit niciun timer numit {name}",
+    "timer_already_exists": "Există deja un timer numit {name}",
+
+    "time_remaining": "Au mai rămas {remaining} din {name}",
+    "timer_remaining": "Au mai rămas {remaining} din timer",
+    "alarm_remaining": "Au mai rămas {remaining} din alarmă",
+    "reminder_remaining": "Au mai rămas {remaining} din reminder",
+
+    "timer_error": "Nu s-a putut interpreta timpul sau intervalul setat"
+  }
+}

--- a/custom_components/view_assist/translations/timers/sr-Latn.json
+++ b/custom_components/view_assist/translations/timers/sr-Latn.json
@@ -1,0 +1,120 @@
+{
+  "decimal_separator": ",",
+  "numbers": {
+    "zero": "nula",
+    "one": ["jedan","jedna"],
+    "two": "dva",
+    "three": "tri",
+    "four": "četiri",
+    "five": "pet",
+    "six": "šest",
+    "seven": "sedam",
+    "eight": "osam",
+    "nine": "devet",
+    "ten": "deset",
+    "eleven": "jedanaest",
+    "twelve": "dvanaest",
+    "thirteen": "trinaest",
+    "fourteen": "četrnaest",
+    "fifteen": "petnaest",
+    "sixteen": "šesnaest",
+    "seventeen": "sedamnaest",
+    "eighteen": "osamnaest",
+    "nineteen": "devetnaest",
+    "twenty": "dvadeset",
+    "twenty one": "dvadeset jedan",
+    "thirty": "trideset",
+    "forty": "četrdeset",
+    "fifty": "pedeset",
+    "sixty": "šezdeset",
+    "seventy": "sedamdeset",
+    "eighty": "osamdeset",
+    "ninety": "devedeset"
+  },
+  "days": {
+    "monday": "ponedeljak",
+    "tuesday": "utorak",
+    "wednesday": "sreda",
+    "thursday": "četvrtak",
+    "friday": "petak",
+    "saturday": "subota",
+    "sunday": "nedelja",
+    "today": "danas",
+    "tomorrow": "sutra"
+  },
+  "durations": {
+    "days": ["dana", "dan"],
+    "hours": ["sati", "sat"],
+    "minutes": ["minuta", "minut"],
+    "seconds": ["sekundi", "sekunda"],
+    "quarter of an hour": ["četvrt sata"],
+    "half an hour": ["pola sata"],
+    "three quarters of an hour": ["tri četvrtine sata"]
+  },
+  "operators": {
+    "before": ["pre"],
+    "after": ["posle"],
+    "plus": ["plus"],
+    "minus": ["minus"]
+  },
+  "time_of_day": {
+    "morning": ["ujutru"],
+    "noon": ["podne"],
+    "afternoon": ["popodne"],
+    "evening": ["uveče"],
+    "night": ["noću"],
+    "midnight": ["ponoć"],
+    "tonight": ["večeras"]
+  },
+  "fractions": {
+    "oclock": [],
+    "half": ["pola"],
+    "quarter": ["četvrt"],
+    "threequarters": ["tri četvrtine"]
+  },
+  "other_words": {
+    "and": ["i"],
+    "the": ["ta", "taj", "te"],
+    "of": ["od"],
+    "in": ["u"],
+    "at": ["u", "na"],
+    "this": ["ovaj", "ova", "ovo"],
+    "on": ["na"]
+  },
+  "direct_translations": {},
+  "structures": {
+    "basic_time": [
+      "{hours} sati",
+      "{hours} sati {time_of_day}",
+      "{hours} sati {minutes}",
+      "{hours} sati {minutes} {time_of_day}",
+      "{hours} sati {operator} {fractions}",
+      "{hours} sati {operator} {fractions} {time_of_day}",
+      "{hours} sati {operator} {minutes}",
+      "{hours} sati {operator} {minutes} {time_of_day}"
+    ],
+    "advanced_time": [
+      "{day} {basic_time}",
+      "{day} u {basic_time}",
+      "{day}, {basic_time}"
+    ],
+    "basic_interval": [
+      "{days} dana i {fractions}",
+      "{hours} sati i {fractions}",
+      "{minutes} minuta i {fractions}",
+      "{hours}h00 i {minutes} minuta"
+    ],
+    "advanced_interval": []
+  },
+  "responses": {
+    "timer_set": "Tajmer podešen na {time}",
+    "timer_named_set": "Tajmer {name} podešen na {time}",
+    "timer_already_exists": "Tajmer sa imenom {name} već postoji",
+    "timer_none": "Нема подешених тајмера",
+    "timer_list": "Imate sledeće podešene tajmere: {timers}",
+    "timer_deleted": "Tajmer {name} obrisan",
+    "timer_not_found": "Tajmer sa imenom {name} nije pronađen",
+    "timer_remaining": "Preostalo je {remaining} na tajmeru {name}",
+    "timer_error": "Nije moguće dekodirati informacije o vremenu ili intervalu"
+  }
+}

--- a/custom_components/view_assist/translations/timers/sr.json
+++ b/custom_components/view_assist/translations/timers/sr.json
@@ -1,0 +1,120 @@
+{
+  "decimal_separator": ",",
+  "numbers": {
+    "zero": "нула",
+    "one": ["један","једна"],
+    "two": "два",
+    "three": "три",
+    "four": "четири",
+    "five": "пет",
+    "six": "шест",
+    "seven": "седам",
+    "eight": "осам",
+    "nine": "девет",
+    "ten": "десет",
+    "eleven": "једанаест",
+    "twelve": "дванаест",
+    "thirteen": "тринаест",
+    "fourteen": "четрнаест",
+    "fifteen": "петнаест",
+    "sixteen": "шеснаест",
+    "seventeen": "седамнаест",
+    "eighteen": "осамнаест",
+    "nineteen": "деветнаест",
+    "twenty": "двадесет",
+    "twenty one": "двадесет један",
+    "thirty": "тридесет",
+    "forty": "четрдесет",
+    "fifty": "педесет",
+    "sixty": "шездесет",
+    "seventy": "седамдесет",
+    "eighty": "осамдесет",
+    "ninety": "деведесет"
+  },
+  "days": {
+    "monday": "понедељак",
+    "tuesday": "уторак",
+    "wednesday": "среда",
+    "thursday": "четвртак",
+    "friday": "петак",
+    "saturday": "субота",
+    "sunday": "недеља",
+    "today": "данас",
+    "tomorrow": "сутра"
+  },
+  "durations": {
+    "days": ["дана", "дан"],
+    "hours": ["сати", "сат"],
+    "minutes": ["минута", "минут"],
+    "seconds": ["секунди", "секунда"],
+    "quarter of an hour": ["четврт сата"],
+    "half an hour": ["пола сата"],
+    "three quarters of an hour": ["три четвртине сата"]
+  },
+  "operators": {
+    "before": ["пре"],
+    "after": ["после"],
+    "plus": ["плус"],
+    "minus": ["минус"]
+  },
+  "time_of_day": {
+    "morning": ["ујутру"],
+    "noon": ["подне"],
+    "afternoon": ["поподне"],
+    "evening": ["увече"],
+    "night": ["ноћу"],
+    "midnight": ["поноћ"],
+    "tonight": ["вечерас"]
+  },
+  "fractions": {
+    "oclock": [],
+    "half": ["пола"],
+    "quarter": ["четврт"],
+    "threequarters": ["три четвртине"]
+  },
+  "other_words": {
+    "and": ["и"],
+    "the": ["та", "тај", "те"],
+    "of": ["од"],
+    "in": ["у"],
+    "at": ["у", "на"],
+    "this": ["овај", "ова", "ово"],
+    "on": ["на"]
+  },
+  "direct_translations": {},
+  "structures": {
+    "basic_time": [
+      "{hours} сати",
+      "{hours} сати {time_of_day}",
+      "{hours} сати {minutes}",
+      "{hours} сати {minutes} {time_of_day}",
+      "{hours} сати {operator} {fractions}",
+      "{hours} сати {operator} {fractions} {time_of_day}",
+      "{hours} сати {operator} {minutes}",
+      "{hours} сати {operator} {minutes} {time_of_day}"
+    ],
+    "advanced_time": [
+      "{day} {basic_time}",
+      "{day} у {basic_time}",
+      "{day}, {basic_time}"
+    ],
+    "basic_interval": [
+      "{days} дана и {fractions}",
+      "{hours} сати и {fractions}",
+      "{minutes} минута и {fractions}",
+      "{hours}h00 и {minutes} минута"
+    ],
+    "advanced_interval": []
+  },
+  "responses": {
+    "timer_set": "Тајмер подешен на {time}",
+    "timer_named_set": "Тајмер {name} подешен на {time}",
+    "timer_already_exists": "Тајмер са именом {name} већ постоји",
+    "timer_none": "Нема подешених тајмера",
+    "timer_list": "Имате следеће подешене тајмере: {timers}",
+    "timer_deleted": "Тајмер {name} обрисан",
+    "timer_not_found": "Тајмер са именом {name} није пронађен",
+    "timer_remaining": "Преостало је {remaining} на тајмеру {name}",
+    "timer_error": "Није могуће декодирати информације о времену или интервалу"
+  }
+}


### PR DESCRIPTION
## Summary

This PR updates `view_assist` navigation handling so companion app tablet navigation works reliably with revert timers and VACA-backed devices.

It ensures navigate/revert actions are forwarded correctly, normalizes `revert_timeout` handling, and keeps the Home Assistant navigation flow aligned with the companion app and VACA integration changes.

## Included changes

- Normalize `revert_timeout` values from service calls
- Register `view_assist.navigate` with a schema that coerces timeout values correctly
- Forward navigate and revert actions to VACA-backed devices
- Prevent duplicate short-interval navigation forwards
- Preserve revert-to-home behavior for timed dashboard navigations

## Validation

Validated using `view_assist.navigate` calls against the Lenovo tablet:

- navigate actions reach the tablet correctly
- `revert_timeout` works correctly from HA service calls
- revert navigation returns to the expected home route
- the tablet then re-enters screensaver correctly under the companion app/VACA flow

## Related changes

This PR is one part of a coordinated update across the companion app and Home Assistant integrations.

Related PRs:
- App: msp1974/ViewAssistCompanionApp#27
- VACA integration: msp1974/ViewAssist_Companion_App#203

Recommended rollout: merge and deploy the related PRs together.
